### PR TITLE
Wrong terminal settings on exit.

### DIFF
--- a/clamshell-impl-plugins/src/main/java/org/clamshellcli/impl/CliConsole.java
+++ b/clamshell-impl-plugins/src/main/java/org/clamshellcli/impl/CliConsole.java
@@ -67,7 +67,7 @@ public class CliConsole implements IOConsole{
     private FileHistory history;
     
     static {
-        TERM = TerminalFactory.create();
+        TERM = TerminalFactory.get();
         AnsiConsole.systemInstall();
         Ansi.setEnabled(true);
         


### PR DESCRIPTION
There is a small problem with terminals info. The effect is that when application exits,
terminal remains in a state when echoing is disabled.

When UnixTerminal object is created, the original term info is recorded into it's internal field [settings].
At the same time a shutdown hook is registered so, that when jvm exits, termial's info get restored [with the recorded settings].

TerminalFactory.create() method unconditionally creates a new instance of UnixTerminal which is _not_ saved internally.
So later calls to TerminalFactory.get() would create a new instance of UnixTerminal and, if called after create(),
will record already altered info, which in turn will be restored in it's shutdown hook.

Shutdown hooks are run in parallel. So there is no particular order of execution and the second terminal created could restore
it's settings after the first one, leaving term in a wrong state.

The simplest solution is not to use TerminalFactory.create() but use TerminalFactory.get() instead, which guarantees to
return the same instance of the terminal.